### PR TITLE
ci: add Docker image details as PR comments

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -12,6 +12,10 @@ on:
         required: true
       docker_hub_password:
         required: true
+    outputs:
+      version:
+        description: The semantic version of the built Docker image
+        value: ${{ jobs.build.outputs.version }}
 
 concurrency:
   # Scoped per-workflow and ref. Version collision safety is handled by the caller
@@ -28,6 +32,8 @@ jobs:
   #  uses: ./.github/workflows/integration-tests.yaml
 
   build:
+    outputs:
+      version: ${{ steps.semver.outputs.version }}
     permissions:
       actions: read
       checks: write

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,82 @@ jobs:
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
+  comment-docker-image:
+    needs: main-build-and-release
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Find merged PR
+        id: find-pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const merged = prs.find(pr => pr.merged_at);
+            if (merged) {
+              core.setOutput('pr_number', merged.number);
+              core.info(`Found merged PR #${merged.number}`);
+            } else {
+              core.warning('No merged PR found for this commit');
+            }
+
+      - name: Comment Docker image details on PR
+        if: steps.find-pr.outputs.pr_number
+        uses: actions/github-script@v8
+        env:
+          IMAGE_VERSION: ${{ needs.main-build-and-release.outputs.version }}
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
+        with:
+          script: |
+            const version = process.env.IMAGE_VERSION;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const image = 'eddgrant/lan2rf-gateway-stats';
+            const marker = '<!-- docker-image-details -->';
+            const body = [
+              marker,
+              '### Docker Image Published (Release)',
+              '',
+              '| | |',
+              '|---|---|',
+              `| **Image** | \`${image}\` |`,
+              `| **Tag** | \`${version}\` |`,
+              `| **Latest** | :white_check_mark: \`latest\` tag updated |`,
+              `| **Pull** | \`docker pull ${image}:${version}\` |`,
+              '',
+              `[:link: View on Docker Hub](https://hub.docker.com/r/${image}/tags?name=${version})`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created new comment on PR #${prNumber}`);
+            }
+
   update-docker-hub-documentation:
     needs: main-build-and-release
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,3 +20,57 @@ jobs:
     secrets:
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+  comment-docker-image:
+    needs: pr-build-and-release
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment Docker image details on PR
+        uses: actions/github-script@v8
+        env:
+          IMAGE_VERSION: ${{ needs.pr-build-and-release.outputs.version }}
+        with:
+          script: |
+            const version = process.env.IMAGE_VERSION;
+            const image = 'eddgrant/lan2rf-gateway-stats';
+            const marker = '<!-- docker-image-details -->';
+            const body = [
+              marker,
+              '### Docker Image Published',
+              '',
+              '| | |',
+              '|---|---|',
+              `| **Image** | \`${image}\` |`,
+              `| **Tag** | \`${version}\` |`,
+              `| **Pull** | \`docker pull ${image}:${version}\` |`,
+              '',
+              `[:link: View on Docker Hub](https://hub.docker.com/r/${image}/tags?name=${version})`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info(`Created new comment on PR #${context.issue.number}`);
+            }


### PR DESCRIPTION
## Summary
- Expose the semantic version as an output from the reusable `build-and-deploy.yaml` workflow
- On PR builds, post a comment with the published Docker image name, tag, pull command, and Docker Hub link
- On main builds, find the merged PR and post a release comment (including `:latest` tag update notice)
- Comments use a marker for idempotent updates — successive pushes to a PR update the same comment

## Test plan
- [ ] Open a test PR and verify the Docker image comment appears after the build completes
- [ ] Merge the PR and verify the release comment appears on the closed PR
- [ ] Push a second commit to a PR and verify the existing comment is updated (not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)