### PR TITLE
feat: support optional HTTP Basic Auth for LAN2RF devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,49 @@ docker run --rm \
     eddgrant/lan2rf-gateway-stats:local
 ```
 
+## Authentication
+
+By default, `lan2rf-gateway-stats` talks to the LAN2RF device anonymously. This matches the LAN2RF's default, where HTTP Basic Auth is disabled.
+
+If you have enabled Basic Auth on your LAN2RF device, set **both** of the following environment variables to provide credentials:
+
+- `LAN2RF_BASIC_AUTH_USERNAME`
+- `LAN2RF_BASIC_AUTH_PASSWORD`
+
+If only one is set, Basic Auth remains disabled. Example:
+
+```shell
+docker run --rm \
+  --net=lan2rf-gateway-stats \
+  --env LAN2RF_CHECK_INTERVAL=30s \
+  --env LAN2RF_URL="http://192.168.2.58" \
+  --env LAN2RF_BASIC_AUTH_USERNAME="my-lan2rf-user" \
+  --env LAN2RF_BASIC_AUTH_PASSWORD="my-lan2rf-password" \
+  --env INFLUXDB_ORG="my-influxdb-org" \
+  --env INFLUXDB_BUCKET="intergas" \
+  --env INFLUXDB_TOKEN="my-very-secure-influxdb-token" \
+  --env INFLUXDB_URL="http://influxdb:8086?connectTimeout=5S&readTimeout=5S&writeTimeout=5S" \
+    eddgrant/lan2rf-gateway-stats:local
+```
+
+You can verify the configuration by looking for the `basicAuthEnabled` field in the startup log line, e.g.
+
+```
+INFO  c.e.l.intergas.LAN2RFConfiguration - LAN2RF Configuration: source='lan2rf', ..., basicAuthEnabled='true'
+```
+
+If authentication fails (HTTP 401 or 403), the application logs an error message naming the two environment variables and will automatically retry on the next polling interval. The application does not crash on auth failure.
+
+### :warning: Security warning — Basic Auth over plaintext HTTP
+
+The LAN2RF does **not** support TLS, so all traffic between this application and the device — including HTTP Basic Auth credentials — travels over the network in plaintext. HTTP Basic Auth sends the `Authorization: Basic <base64(username:password)>` header on every request; **base64 is encoding, not encryption**. Anyone able to observe traffic on your LAN can trivially recover the credentials.
+
+If you enable Basic Auth on your LAN2RF:
+
+- Only use it on a trusted, well-segmented network.
+- Treat the credentials as low-value and **rotate them frequently**.
+- **Never reuse** the password for any other system or account.
+
 ## The Data
 
 The application publishes several types of measurements to InfluxDB, each representing a different aspect of the heating system's status.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     testImplementation("org.testcontainers:influxdb:1.21.4")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.wiremock:wiremock-standalone:3.13.2")
+    testImplementation("ch.qos.logback:logback-classic")
 
     annotationProcessor("io.micronaut.validation:micronaut-validation-processor")
     implementation("io.micronaut.validation:micronaut-validation")

--- a/src/main/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFBasicAuthClientFilter.kt
+++ b/src/main/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFBasicAuthClientFilter.kt
@@ -1,0 +1,16 @@
+package com.eddgrant.lan2rfgatewaystats.intergas
+
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.annotation.ClientFilter
+import io.micronaut.http.annotation.RequestFilter
+
+@ClientFilter(serviceId = ["lan2rf"])
+class LAN2RFBasicAuthClientFilter(private val config: LAN2RFConfiguration) {
+
+    @RequestFilter
+    fun addBasicAuth(request: MutableHttpRequest<*>) {
+        if (config.isBasicAuthEnabled()) {
+            request.basicAuth(config.basicAuth.username!!, config.basicAuth.password!!)
+        }
+    }
+}

--- a/src/main/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFConfiguration.kt
+++ b/src/main/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFConfiguration.kt
@@ -24,6 +24,8 @@ class LAN2RFConfiguration {
 
     var measurements = Measurements()
 
+    var basicAuth = BasicAuth()
+
     @ConfigurationProperties("measurements")
     data class Measurements(
         var boiler: Boolean = true,
@@ -31,17 +33,27 @@ class LAN2RFConfiguration {
         var room2: Boolean = true
     )
 
+    @ConfigurationProperties("basic-auth")
+    class BasicAuth {
+        var username: String? = null
+        var password: String? = null
+    }
+
+    fun isBasicAuthEnabled(): Boolean =
+        !basicAuth.username.isNullOrBlank() && !basicAuth.password.isNullOrBlank()
+
     @PostConstruct
     fun logConfiguration() {
         LOGGER.info(
-            "LAN2RF Configuration: source='{}', room1Name='{}', room2Name='{}', checkInterval='{}', measurements.boiler='{}', measurements.room1='{}', measurements.room2='{}'",
+            "LAN2RF Configuration: source='{}', room1Name='{}', room2Name='{}', checkInterval='{}', measurements.boiler='{}', measurements.room1='{}', measurements.room2='{}', basicAuthEnabled='{}'",
             source,
             room1Name,
             room2Name,
             checkInterval,
             measurements.boiler,
             measurements.room1,
-            measurements.room2
+            measurements.room2,
+            isBasicAuthEnabled()
         )
     }
 

--- a/src/main/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFRepository.kt
+++ b/src/main/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFRepository.kt
@@ -1,6 +1,7 @@
 package com.eddgrant.lan2rfgatewaystats.intergas
 
 import io.micronaut.http.client.exceptions.HttpClientException
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import jakarta.inject.Singleton
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -17,6 +18,20 @@ class LAN2RFRepository(
         return Flux.interval(laN2RFConfiguration.checkInterval)
             .flatMap {
                 intergasService.getStatusData()
+                    .onErrorResume(HttpClientResponseException::class.java) { e ->
+                        val code = e.status.code
+                        if (code == 401 || code == 403) {
+                            LOGGER.error(
+                                "LAN2RF authentication failed (HTTP {}). " +
+                                    "Check LAN2RF_BASIC_AUTH_USERNAME and LAN2RF_BASIC_AUTH_PASSWORD. " +
+                                    "Will retry on next interval.",
+                                code
+                            )
+                        } else {
+                            LOGGER.error("LAN2RF returned HTTP {}. Will retry on next interval.", code, e)
+                        }
+                        Mono.empty()
+                    }
                     .onErrorResume(HttpClientException::class.java) { e ->
                         LOGGER.error("Failed to get status data from LAN2RF device. Will retry on next interval.", e)
                         Mono.empty()

--- a/src/test/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFClientIntegrationTest.kt
+++ b/src/test/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFClientIntegrationTest.kt
@@ -1,13 +1,18 @@
 package com.eddgrant.lan2rfgatewaystats.intergas
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.BasicCredentials
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.serde.ObjectMapper
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 
@@ -22,6 +27,7 @@ class LAN2RFClientIntegrationTest(
     }
 
     "it retrieves and deserialises status data from the LAN2RF device" {
+        wireMockServer.resetAll()
         wireMockServer.stubFor(
             get(urlEqualTo("/data.json"))
                 .willReturn(
@@ -43,6 +49,7 @@ class LAN2RFClientIntegrationTest(
     }
 
     "it handles a response with no Content-Type header" {
+        wireMockServer.resetAll()
         wireMockServer.stubFor(
             get(urlEqualTo("/data.json"))
                 .willReturn(
@@ -58,6 +65,53 @@ class LAN2RFClientIntegrationTest(
         val statusData = objectMapper.readValue(httpResponse.body(), StatusData::class.java)
         statusData shouldNotBe null
     }
+
+    // --- Basic Auth --------------------------------------------------------
+    //
+    // The tests below exercise the HTTP Basic Auth client filter. They use
+    // a second, manually-built Micronaut ApplicationContext configured with
+    // `lan2rf.basic-auth.*` credentials rather than the `@MicronautTest`
+    // context used above (which has no credentials configured, matching
+    // the app's default behaviour). Both contexts share the same WireMock
+    // server — each test calls `resetAll()` and installs its own stubs.
+
+    "it sends basic auth credentials when both username and password are configured" {
+        wireMockServer.resetAll()
+        wireMockServer.stubFor(
+            get(urlEqualTo("/data.json"))
+                .withBasicAuth(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD)
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withBody(STATUS_DATA_JSON)
+                )
+        )
+
+        val httpResponse = basicAuthClient.getStatusData().block()!!
+
+        httpResponse.status.code shouldBe 200
+        val statusData = objectMapper.readValue(httpResponse.body(), StatusData::class.java)
+        statusData shouldNotBe null
+        statusData.nodenr shouldBe 200
+
+        wireMockServer.verify(
+            getRequestedFor(urlEqualTo("/data.json"))
+                .withBasicAuth(BasicCredentials(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD))
+        )
+    }
+
+    "it surfaces a 401 as an HttpClientResponseException when basic auth credentials are rejected" {
+        wireMockServer.resetAll()
+        wireMockServer.stubFor(
+            get(urlEqualTo("/data.json"))
+                .willReturn(aResponse().withStatus(401))
+        )
+
+        val ex = shouldThrow<HttpClientResponseException> {
+            basicAuthClient.getStatusData().block()
+        }
+        ex.status.code shouldBe 401
+    }
 }) {
     companion object {
         val wireMockServer = WireMockServer(wireMockConfig().dynamicPort()).apply { start() }
@@ -66,6 +120,28 @@ class LAN2RFClientIntegrationTest(
             // Set before Micronaut context creation so the LAN2RF URL placeholder resolves
             System.setProperty("LAN2RF_URL", wireMockServer.baseUrl())
         }
+
+        private const val BASIC_AUTH_USERNAME = "admin"
+        private const val BASIC_AUTH_PASSWORD = "s3cret"
+
+        /**
+         * A second Micronaut context, configured with basic auth credentials,
+         * pointed at the same WireMock server as the `@MicronautTest` context.
+         * Used by the basic-auth test cases.
+         */
+        private val basicAuthContext: ApplicationContext by lazy {
+            ApplicationContext.run(
+                mapOf(
+                    "micronaut.http.services.lan2rf.urls" to listOf(wireMockServer.baseUrl()),
+                    "lan2rf.basic-auth.username" to BASIC_AUTH_USERNAME,
+                    "lan2rf.basic-auth.password" to BASIC_AUTH_PASSWORD,
+                    // Keep the background poller from competing with the explicit test calls.
+                    "lan2rf.check-interval" to "1h"
+                )
+            )
+        }
+
+        val basicAuthClient: LAN2RFClient by lazy { basicAuthContext.getBean(LAN2RFClient::class.java) }
 
         val STATUS_DATA_JSON = """
             {

--- a/src/test/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFConfigurationTest.kt
+++ b/src/test/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFConfigurationTest.kt
@@ -28,4 +28,40 @@ class LAN2RFConfigurationTest : StringSpec({
         lan2rfConfiguration.measurements.room1.shouldBe(true)
         lan2rfConfiguration.measurements.room2.shouldBe(true)
     }
+
+    "Basic auth is disabled by default" {
+        lan2rfConfiguration.basicAuth.username.shouldBe(null)
+        lan2rfConfiguration.basicAuth.password.shouldBe(null)
+        lan2rfConfiguration.isBasicAuthEnabled().shouldBe(false)
+    }
+
+    "Basic auth is disabled when only the username is set" {
+        val config = LAN2RFConfiguration().apply {
+            basicAuth.username = "admin"
+        }
+        config.isBasicAuthEnabled().shouldBe(false)
+    }
+
+    "Basic auth is disabled when only the password is set" {
+        val config = LAN2RFConfiguration().apply {
+            basicAuth.password = "s3cret"
+        }
+        config.isBasicAuthEnabled().shouldBe(false)
+    }
+
+    "Basic auth is disabled when username or password is blank" {
+        val config = LAN2RFConfiguration().apply {
+            basicAuth.username = "   "
+            basicAuth.password = "s3cret"
+        }
+        config.isBasicAuthEnabled().shouldBe(false)
+    }
+
+    "Basic auth is enabled when both username and password are set" {
+        val config = LAN2RFConfiguration().apply {
+            basicAuth.username = "admin"
+            basicAuth.password = "s3cret"
+        }
+        config.isBasicAuthEnabled().shouldBe(true)
+    }
 })

--- a/src/test/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFRepositoryTest.kt
+++ b/src/test/kotlin/com/eddgrant/lan2rfgatewaystats/intergas/LAN2RFRepositoryTest.kt
@@ -1,11 +1,20 @@
 package com.eddgrant.lan2rfgatewaystats.intergas
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveAtLeastSize
+import io.kotest.matchers.string.shouldContain
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.exceptions.HttpClientException
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
 import io.mockk.every
 import io.mockk.mockk
+import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 import java.time.Duration
@@ -28,6 +37,43 @@ class LAN2RFRepositoryTest(
             .expectNext(StatusDataTestFixtures.BASIC)
             .thenCancel()
             .verify()
+    }
+
+    "it logs an authentication-failure message and continues polling on HTTP 401" {
+        // Given
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        val repoLogger = LoggerFactory.getLogger(LAN2RFRepository::class.java) as Logger
+        repoLogger.addAppender(appender)
+
+        val unauthorized = HttpClientResponseException(
+            "Unauthorized",
+            HttpResponse.status<Any>(HttpStatus.UNAUTHORIZED)
+        )
+        every { intergasService.getStatusData() } returnsMany listOf(
+            Mono.error(unauthorized),
+            Mono.just(StatusDataTestFixtures.BASIC)
+        )
+
+        // When / Then
+        try {
+            StepVerifier.withVirtualTime { lan2rfRepository.getStatusData() }
+                .expectSubscription()
+                .thenAwait(lan2rfConfiguration.checkInterval)
+                .thenAwait(lan2rfConfiguration.checkInterval)
+                .expectNext(StatusDataTestFixtures.BASIC)
+                .thenCancel()
+                .verify()
+
+            appender.list.shouldHaveAtLeastSize(1)
+            val message = appender.list.first { it.level.levelStr == "ERROR" }.formattedMessage
+            message shouldContain "authentication failed"
+            message shouldContain "401"
+            message shouldContain "LAN2RF_BASIC_AUTH_USERNAME"
+            message shouldContain "LAN2RF_BASIC_AUTH_PASSWORD"
+        } finally {
+            repoLogger.detachAppender(appender)
+            appender.stop()
+        }
     }
 
     "it continues to poll for data when there is a connect exception" {


### PR DESCRIPTION
## Summary

- Adds optional HTTP Basic Auth support for LAN2RF devices via `LAN2RF_BASIC_AUTH_USERNAME` / `LAN2RF_BASIC_AUTH_PASSWORD`. Default behaviour is unchanged: when no credentials are configured, requests are sent anonymously.
- Credentials are applied through a Micronaut `@ClientFilter(serviceId = ["lan2rf"])`. The startup log line now reports `basicAuthEnabled`, and 401/403 responses are logged with an actionable message naming both env vars; the poller keeps retrying on the next interval.
- New `Authentication` section in the README explains how to enable the feature and prominently warns that LAN2RF devices speak plaintext HTTP — Basic Auth credentials travel in the clear and should be rotated frequently and never reused.

Implements [`docs/features/001-support-lan2rf-devices-with-basic-auth.md`](docs/features/001-support-lan2rf-devices-with-basic-auth.md).

## Test plan

- [x] `./gradlew test` — unit tests pass, including new `LAN2RFConfigurationTest` cases for `isBasicAuthEnabled()` edge cases.
- [x] `./gradlew integrationTest --tests "*LAN2RFClient*"` — all four `LAN2RFClientIntegrationTest` cases pass:
  - back-compat: anonymous request with stubbed 200
  - back-compat: response with no Content-Type header
  - new: WireMock `withBasicAuth` stub matches and `verify(... withBasicAuth(BasicCredentials(...)))` confirms the header was sent
  - new: 401 surfaces as `HttpClientResponseException`
- [x] New `LAN2RFRepositoryTest` case attaches a Logback `ListAppender` and asserts the auth-failure log line contains `"authentication failed"`, `"401"`, `LAN2RF_BASIC_AUTH_USERNAME`, and `LAN2RF_BASIC_AUTH_PASSWORD`, then verifies polling continues on the next tick.
- [ ] Manual smoke test against a real LAN2RF device with Basic Auth enabled (suggested before merge).

> Note: there is one pre-existing flaky failure in `StatusDataPublisherIntegrationTest` (`ClosedReceiveChannelException`) that reproduces on `main` without these changes. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)