### PR TITLE
chore(deps): adopt shared renovate-config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "packageRules": [
-    {
-      "groupName": "Micronaut Platform",
-      "groupSlug": "micronaut-platform",
-      "matchPackageNames": [
-        "io.micronaut.platform.*"
-      ]
-    },
-    {
-      "groupName": "Micronaut",
-      "groupSlug": "micronaut",
-      "matchPackageNames": [
-        "io.micronaut.*"
-      ]
-    },
-    {
-      "groupName": "Jetbrains Kotlin",
-      "groupSlug": "jetbrains-platform",
-      "matchPackageNames": [
-        "org.jetbrains.kotlin.*"
-      ]
-    }
-  ]
+  "extends": ["github>eddgrant/renovate-config"]
 }


### PR DESCRIPTION
## Summary
- Swaps `config:recommended` for [`eddgrant/renovate-config`](https://github.com/eddgrant/renovate-config).
- Drops the local Micronaut and Kotlin `packageRules` — both are already covered by the shared preset.
- Picks up the 21-day release-age gate, Gradle-wrapper / GitHub-Actions grouping, and `chore(deps): …` commit prefixes.

## Test plan
- [ ] Renovate Dependency Dashboard refreshes; in-flight Renovate PRs reconcile against the new rules.
- [ ] Future Micronaut and Kotlin updates open as single grouped PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)